### PR TITLE
Add Factory Creatures mod with Factory submod

### DIFF
--- a/vcmi-1.4.json
+++ b/vcmi-1.4.json
@@ -345,6 +345,17 @@
 		],
 		"downloadSize" : 18.849
 	},
+	"factory_creatures" : {
+		"mod" : "https://github.com/Olegmods/Factory_creatures/blob/main/Factory_creatures/mod.json",
+		"download" : "https://github.com/Olegmods/Factory_creatures/archive/refs/heads/main.zip",
+		"screenshots" : [
+			"https://raw.githubusercontent.com/Olegmods/Factory_creatures/main/Screenshots/screen1.png",
+			"https://raw.githubusercontent.com/Olegmods/Factory_creatures/main/Screenshots/screen2.png",
+			"https://raw.githubusercontent.com/Olegmods/Factory_creatures/main/Screenshots/screen3.png",
+			"https://raw.githubusercontent.com/Olegmods/Factory_creatures/main/Screenshots/screen4.png"
+		],
+		"downloadSize" : 135.555
+	},
 	"cetatea-town" : {
 		"mod" : "https://raw.githubusercontent.com/vcmi-mods/cetatea-town/vcmi-1.4/cetatea/mod.json",
 		"download" : "https://github.com/vcmi-mods/cetatea-town/archive/refs/heads/vcmi-1.4.zip",

--- a/vcmi-1.5.json
+++ b/vcmi-1.5.json
@@ -345,6 +345,17 @@
 		],
 		"downloadSize" : 18.849
 	},
+	"factory_creatures" : {
+		"mod" : "https://github.com/Olegmods/Factory_creatures/blob/main/Factory_creatures/mod.json",
+		"download" : "https://github.com/Olegmods/Factory_creatures/archive/refs/heads/main.zip",
+		"screenshots" : [
+			"https://raw.githubusercontent.com/Olegmods/Factory_creatures/main/Screenshots/screen1.png",
+			"https://raw.githubusercontent.com/Olegmods/Factory_creatures/main/Screenshots/screen2.png",
+			"https://raw.githubusercontent.com/Olegmods/Factory_creatures/main/Screenshots/screen3.png",
+			"https://raw.githubusercontent.com/Olegmods/Factory_creatures/main/Screenshots/screen4.png"
+		],
+		"downloadSize" : 135.555
+	},
 	"cetatea-town" : {
 		"mod" : "https://raw.githubusercontent.com/vcmi-mods/cetatea-town/vcmi-1.4/cetatea/mod.json",
 		"download" : "https://github.com/vcmi-mods/cetatea-town/archive/refs/heads/vcmi-1.4.zip",


### PR DESCRIPTION
Not long ago, I made a mod that revives the old Factory's concept (i.e. 2019 demo town screen).
Let me note that this Factory differs in many ways from the original, many of whose features are not implemented in VCMI (Automatons with another ability, Dreadnoughts always using wide breath, fairy outdated stats compared to HotA's and Couatls with Tides of War ability). But this city also has many advantages. For example, an alternative unit (Termotron) and 2 pairs of units (level 2 (Rogues and Mechanics (due to the VCMI and HotA mechanic, the mechanic will be pre-built, I'd rather added them as alternate creatures, but Rogues' dwelling will be unavailable most of the time) and level 7 (Couatls and Dreadnoughts)), which can be built in one city. Couatl being renamed to Rainbow Couatl to be comparatible with Tides of War mod.