### PR TITLE
Added repository file for vcmi-1.7

### DIFF
--- a/.github/update_size.py
+++ b/.github/update_size.py
@@ -11,7 +11,7 @@ for filename in glob.glob(os.path.join('.', '*.json')):
         print(f"Opening: {filename}")
         filecontent = open(filename, "r").read()
         modlist = json.loads(filecontent)
-        for mod, data in modlist.items():
+        for mod, data in modlist.items() if 'availableMods' not in modlist else modlist["availableMods"].items():
             url = data["download"].replace(" ", "%20")
             print(f"Download {mod}: {url}")
             try:

--- a/.github/validate_mod_json.py
+++ b/.github/validate_mod_json.py
@@ -23,7 +23,7 @@ for filename in glob.glob(os.path.join('.', '*.json')):
             print(f"❌ Error reading JSON file {filename}: {err}")
             continue
 
-        for mod, data in modlist.items():
+        for mod, data in modlist.items() if 'availableMods' not in modlist else modlist["availableMods"].items():
             url = data["mod"].replace(" ", "%20")
             print(f"{mod}: {url}")
 

--- a/vcmi-1.7.json
+++ b/vcmi-1.7.json
@@ -1,0 +1,1021 @@
+{
+	"availableMods" :
+	{
+		"vcmi-extras" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/vcmi-extras/vcmi-1.7/mod.json",
+			"download" : "https://github.com/vcmi-mods/vcmi-extras/archive/refs/heads/vcmi-1.7.zip",
+			"downloadSize" : 2.175
+		},
+		"hota" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/horn-of-the-abyss/vcmi-1.6/hota/mod.json",
+			"download" : "https://github.com/vcmi-mods/horn-of-the-abyss/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/horn-of-the-abyss/vcmi-1.4/screenshots/01.png",
+				"https://raw.githubusercontent.com/vcmi-mods/horn-of-the-abyss/vcmi-1.4/screenshots/02.png",
+				"https://raw.githubusercontent.com/vcmi-mods/horn-of-the-abyss/vcmi-1.4/screenshots/03.png",
+				"https://raw.githubusercontent.com/vcmi-mods/horn-of-the-abyss/vcmi-1.4/screenshots/04.png",
+				"https://raw.githubusercontent.com/vcmi-mods/horn-of-the-abyss/vcmi-1.4/screenshots/05.png",
+				"https://raw.githubusercontent.com/vcmi-mods/horn-of-the-abyss/vcmi-1.4/screenshots/06.png",
+				"https://raw.githubusercontent.com/vcmi-mods/horn-of-the-abyss/vcmi-1.4/screenshots/07.png",
+				"https://raw.githubusercontent.com/vcmi-mods/horn-of-the-abyss/vcmi-1.4/screenshots/08.png",
+				"https://raw.githubusercontent.com/vcmi-mods/horn-of-the-abyss/vcmi-1.4/screenshots/09.png",
+				"https://raw.githubusercontent.com/vcmi-mods/horn-of-the-abyss/vcmi-1.6/screenshots/wiki1.png",
+				"https://raw.githubusercontent.com/vcmi-mods/horn-of-the-abyss/vcmi-1.6/screenshots/wiki2.png",
+				"https://raw.githubusercontent.com/vcmi-mods/horn-of-the-abyss/vcmi-1.6/screenshots/wiki3.png"
+			],
+			"downloadSize" : 102.594
+		},
+		"wake-of-gods" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/wake-of-gods/vcmi-1.6/mod.json",
+			"download" : "https://github.com/vcmi-mods/wake-of-gods/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 66.251
+		},
+		"tides-of-war" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/tides-of-war/vcmi-1.6/mod.json",
+			"download" : "https://github.com/vcmi-mods/tides-of-war/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 29.246
+		},
+		"courtyard" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/courtyard/vcmi-1.6/Courtyard/mod.json",
+			"download" : "https://github.com/vcmi-mods/courtyard/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/courtyard/vcmi-1.6/screenshots/screen1.png",
+				"https://raw.githubusercontent.com/vcmi-mods/courtyard/vcmi-1.6/screenshots/screen2.png",
+				"https://raw.githubusercontent.com/vcmi-mods/courtyard/vcmi-1.6/screenshots/screen3.png",
+				"https://raw.githubusercontent.com/vcmi-mods/courtyard/vcmi-1.6/screenshots/screen4.png",
+				"https://raw.githubusercontent.com/vcmi-mods/courtyard/vcmi-1.6/screenshots/wiki1.png",
+				"https://raw.githubusercontent.com/vcmi-mods/courtyard/vcmi-1.6/screenshots/wiki2.png",
+				"https://raw.githubusercontent.com/vcmi-mods/courtyard/vcmi-1.6/screenshots/wiki3.png",
+				"https://raw.githubusercontent.com/vcmi-mods/courtyard/vcmi-1.6/screenshots/wiki4.png",
+				"https://raw.githubusercontent.com/vcmi-mods/courtyard/vcmi-1.6/screenshots/wiki5.png",
+				"https://raw.githubusercontent.com/vcmi-mods/courtyard/vcmi-1.6/screenshots/lore_part1.png",
+				"https://raw.githubusercontent.com/vcmi-mods/courtyard/vcmi-1.6/screenshots/lore_part2.png"
+			],
+			"downloadSize" : 32.837
+		},
+		"neutral-heroes" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/neutral-heroes/vcmi-1.6/mod.json",
+			"download" : "https://github.com/vcmi-mods/neutral-heroes/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 2.613
+		},
+		"new-old-heroes" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/new-old-heroes/vcmi-1.6/new-old-heroes/mod.json",
+			"download" : "https://github.com/vcmi-mods/new-old-heroes/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 6.304,
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/new-old-heroes/vcmi-1.6/screenshots/StandaloneSoth.png",
+				"https://raw.githubusercontent.com/vcmi-mods/new-old-heroes/vcmi-1.6/screenshots/StandaloneNicolas.png",
+				"https://raw.githubusercontent.com/vcmi-mods/new-old-heroes/vcmi-1.6/screenshots/StandaloneKastore.png",
+				"https://raw.githubusercontent.com/vcmi-mods/new-old-heroes/vcmi-1.6/screenshots/StandaloneGwenneth.png",
+				"https://raw.githubusercontent.com/vcmi-mods/new-old-heroes/vcmi-1.6/screenshots/StandaloneEscatonForge2k.png",
+				"https://raw.githubusercontent.com/vcmi-mods/new-old-heroes/vcmi-1.6/screenshots/StandaloneEscatonForge.png",
+				"https://raw.githubusercontent.com/vcmi-mods/new-old-heroes/vcmi-1.6/screenshots/StandaloneBalindar.png",
+				"https://raw.githubusercontent.com/vcmi-mods/new-old-heroes/vcmi-1.6/screenshots/StandaloneArchibald.png",
+				"https://raw.githubusercontent.com/vcmi-mods/new-old-heroes/vcmi-1.6/screenshots/StandaloneGauldoth.png",
+				"https://raw.githubusercontent.com/vcmi-mods/new-old-heroes/vcmi-1.6/screenshots/StandaloneGolwyn.png",
+				"https://raw.githubusercontent.com/vcmi-mods/new-old-heroes/vcmi-1.6/screenshots/StandaloneLysander.png",
+				"https://raw.githubusercontent.com/vcmi-mods/new-old-heroes/vcmi-1.6/screenshots/StandaloneMirael.png",
+				"https://raw.githubusercontent.com/vcmi-mods/new-old-heroes/vcmi-1.6/screenshots/StandaloneRavenwood.png",
+				"https://raw.githubusercontent.com/vcmi-mods/new-old-heroes/vcmi-1.6/screenshots/StandaloneWaerjak.png"
+			]
+		},
+		"asylum-town" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/asylum-town/vcmi-1.6/asylum-town/mod.json",
+			"download" : "https://github.com/vcmi-mods/asylum-town/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/asylum-town/main/screenshots/screen1.png",
+				"https://raw.githubusercontent.com/vcmi-mods/asylum-town/main/screenshots/screen2.png",
+				"https://raw.githubusercontent.com/vcmi-mods/asylum-town/main/screenshots/screen3.png",
+				"https://raw.githubusercontent.com/vcmi-mods/asylum-town/main/screenshots/screen4.png",
+				"https://raw.githubusercontent.com/vcmi-mods/asylum-town/main/screenshots/screen5.png",
+				"https://raw.githubusercontent.com/vcmi-mods/asylum-town/main/screenshots/screen6.png",
+				"https://raw.githubusercontent.com/vcmi-mods/asylum-town/main/screenshots/screen7.png"
+			],
+			"downloadSize" : 26.66
+		},
+		"highlands-town" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/highlands-town/vcmi-1.6/highlands-town/mod.json",
+			"download" : "https://github.com/vcmi-mods/highlands-town/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/highlands-town/vcmi-1.6/screenshots/screen1.png",
+				"https://raw.githubusercontent.com/vcmi-mods/highlands-town/vcmi-1.6/screenshots/screen2.png",
+				"https://raw.githubusercontent.com/vcmi-mods/highlands-town/vcmi-1.6/screenshots/screen3.png"
+			],
+			"downloadSize" : 15.552
+		},
+		"new-pavilion" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/new-pavilion/vcmi-1.6/New Pavilion/mod.json",
+			"download" : "https://github.com/vcmi-mods/new-pavilion/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/new-pavilion/vcmi-1.4/screenshots/screen1.png",
+				"https://raw.githubusercontent.com/vcmi-mods/new-pavilion/vcmi-1.4/screenshots/screen2.png",
+				"https://raw.githubusercontent.com/vcmi-mods/new-pavilion/vcmi-1.4/screenshots/screen3.png",
+				"https://raw.githubusercontent.com/vcmi-mods/new-pavilion/vcmi-1.4/screenshots/screen4.png",
+				"https://raw.githubusercontent.com/vcmi-mods/new-pavilion/vcmi-1.4/screenshots/screen5.png",
+				"https://raw.githubusercontent.com/vcmi-mods/new-pavilion/vcmi-1.4/screenshots/screen6.png",
+				"https://raw.githubusercontent.com/vcmi-mods/new-pavilion/vcmi-1.4/screenshots/screen7.png"
+			],
+			"downloadSize" : 63.319
+		},
+		"cathedral-town" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/cathedral-town/vcmi-1.6/cathedral-town/mod.json",
+			"download" : "https://github.com/vcmi-mods/cathedral-town/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/cathedral-town/vcmi-1.6/screenshots/screen1.png",
+				"https://raw.githubusercontent.com/vcmi-mods/cathedral-town/vcmi-1.6/screenshots/screen2.png",
+				"https://raw.githubusercontent.com/vcmi-mods/cathedral-town/vcmi-1.6/screenshots/screen3.png"
+			],
+			"downloadSize" : 12.992
+		},
+		"death-valley-town" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/death-valley-town/vcmi-1.6/death-valley-town/mod.json",
+			"download" : "https://github.com/vcmi-mods/death-valley-town/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 20.105
+		},
+		"reworked-commanders" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/reworked-commanders/vcmi-1.6/reworked-commanders/mod.json",
+			"download" : "https://github.com/vcmi-mods/reworked-commanders/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 9.266
+		},
+		"andruids-expansion" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/andruids-expansion/vcmi-1.6/andruids-expansion/mod.json",
+			"download" : "https://github.com/vcmi-mods/andruids-expansion/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/andruids-expansion/vcmi-1.6/screenshots/screen1.png",
+				"https://raw.githubusercontent.com/vcmi-mods/andruids-expansion/vcmi-1.6/screenshots/screen2.png",
+				"https://raw.githubusercontent.com/vcmi-mods/andruids-expansion/vcmi-1.6/screenshots/screen3.png",
+				"https://raw.githubusercontent.com/vcmi-mods/andruids-expansion/vcmi-1.6/screenshots/screen4.png",
+				"https://raw.githubusercontent.com/vcmi-mods/andruids-expansion/vcmi-1.6/screenshots/screen5.png",
+				"https://raw.githubusercontent.com/vcmi-mods/andruids-expansion/vcmi-1.6/screenshots/screen6.png",
+				"https://raw.githubusercontent.com/vcmi-mods/andruids-expansion/vcmi-1.6/screenshots/screen7.png",
+				"https://raw.githubusercontent.com/vcmi-mods/andruids-expansion/vcmi-1.6/screenshots/screen8.png",
+				"https://raw.githubusercontent.com/vcmi-mods/andruids-expansion/vcmi-1.6/screenshots/screen9.png",
+				"https://raw.githubusercontent.com/vcmi-mods/andruids-expansion/vcmi-1.6/screenshots/screen10.png",
+				"https://raw.githubusercontent.com/vcmi-mods/andruids-expansion/vcmi-1.6/screenshots/screen11.png",
+				"https://raw.githubusercontent.com/vcmi-mods/andruids-expansion/vcmi-1.6/screenshots/screen12.png",
+				"https://raw.githubusercontent.com/vcmi-mods/andruids-expansion/vcmi-1.6/screenshots/screen13.png"
+			],
+			"downloadSize" : 7.769
+		},
+		"german-translation" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/german-translation/vcmi-1.6/mod.json",
+			"download" : "https://github.com/vcmi-mods/german-translation/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 107.37
+		},
+		"spanish-translation" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/spanish-translation/vcmi-1.6/spanish-translation/mod.json",
+			"download" : "https://github.com/vcmi-mods/spanish-translation/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 13.874
+		},
+		"korean-translation" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/korean-translation/vcmi-1.6/korean-translation/mod.json",
+			"download" : "https://github.com/vcmi-mods/korean-translation/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 4.068
+		},
+		"italian-translation" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/italian-translation/vcmi-1.6/italian-translation/mod.json",
+			"download" : "https://github.com/vcmi-mods/italian-translation/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 14.616
+		},
+		"czech-translation" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/czech-translation/vcmi-1.6/czech-translation/mod.json",
+			"download" : "https://github.com/vcmi-mods/czech-translation/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 9.732
+		},
+		"finnish-translation" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/finnish-translation/vcmi-1.6/finnish-translation/mod.json",
+			"download" : "https://github.com/vcmi-mods/finnish-translation/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 0.59
+		},
+		"portuguese-translation" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/portuguese-translation/vcmi-1.6/portuguese-translation/mod.json",
+			"download" : "https://github.com/vcmi-mods/portuguese-translation/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 10.024
+		},
+		"swedish-translation" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/swedish-translation/vcmi-1.6/swedish-translation/mod.json",
+			"download" : "https://github.com/vcmi-mods/swedish-translation/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 6.654
+		},
+		"turkish-translation" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/turkish-translation/vcmi-1.6/turkish-translation/mod.json",
+			"download" : "https://github.com/vcmi-mods/turkish-translation/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 0.049
+		},
+		"hungarian-translation" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/hungarian-translation/vcmi-1.6/hungarian-translation/mod.json",
+			"download" : "https://github.com/vcmi-mods/hungarian-translation/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 16.348
+		},
+		"chinese-translation" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/chinese-translation/vcmi-1.6/chinese-translation/mod.json",
+			"download" : "https://github.com/vcmi-mods/chinese-translation/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 16.969
+		},
+		"french-translation" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/french-translation/vcmi-1.6/french-translation/mod.json",
+			"download" : "https://github.com/vcmi-mods/french-translation/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 37.709
+		},
+		"vietnamese-translation" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/vietnamese-translation/vcmi-1.6/vietnamese-translation/mod.json",
+			"download" : "https://github.com/vcmi-mods/vietnamese-translation/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 6.051
+		},
+		"polish-translation" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/polish-translation/vcmi-1.6/polish-translation/mod.json",
+			"download" : "https://github.com/vcmi-mods/polish-translation/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 163.969
+		},
+		"vcmi-mod-ce-ukr" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/vcmi-mod-ce-ukr/vcmi-1.6/ce-ukr/mod.json",
+			"download" : "https://github.com/vcmi-mods/vcmi-mod-ce-ukr/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 7.285
+		},
+		"h3-for-vcmi-englisation" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/h3-for-vcmi-englisation/vcmi-1.6/H3forVCMIenglisation/mod.json",
+			"download" : "https://github.com/vcmi-mods/h3-for-vcmi-englisation/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 109.992
+		},
+		"forge" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/forge/vcmi-1.6/forge/mod.json",
+			"download" : "https://github.com/vcmi-mods/forge/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/forge/vcmi-1.6/screenshots/screen1.png",
+				"https://raw.githubusercontent.com/vcmi-mods/forge/vcmi-1.6/screenshots/screen2.png",
+				"https://raw.githubusercontent.com/vcmi-mods/forge/vcmi-1.6/screenshots/screen3.png",
+				"https://raw.githubusercontent.com/vcmi-mods/forge/vcmi-1.6/screenshots/screen4.png",
+				"https://raw.githubusercontent.com/vcmi-mods/forge/vcmi-1.6/screenshots/screen5.png",
+				"https://raw.githubusercontent.com/vcmi-mods/forge/vcmi-1.6/screenshots/screen6.png"
+			],
+			"downloadSize" : 20.144
+		},
+		"ai trace" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/adventure-ai-trace/upstream/mod.json",
+			"download" : "https://github.com/vcmi-mods/adventure-ai-trace/archive/refs/heads/upstream.zip",
+			"downloadSize" : 0.001
+		},
+		"mac demo support" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/mac-demo-support/master/mod.json",
+			"download" : "https://github.com/vcmi-mods/mac-demo-support/archive/refs/heads/master.zip",
+			"downloadSize" : 0.011
+		},
+		"ai testing maps" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/ai-testing-maps/master/mod.json",
+			"download" : "https://github.com/vcmi-mods/ai-testing-maps/archive/refs/heads/master.zip",
+			"downloadSize" : 4.062
+		},
+		"campaign-heroes" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/campaign-heroes/vcmi-1.6/mod.json",
+			"download" : "https://github.com/vcmi-mods/campaign-heroes/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 0.122
+		},
+		"tarnum" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/tarnum/vcmi-1.6/tarnum/mod.json",
+			"download" : "https://github.com/vcmi-mods/tarnum/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/tarnum/vcmi-1.6/screenshots/tarnumVizier.png",
+				"https://raw.githubusercontent.com/vcmi-mods/tarnum/vcmi-1.6/screenshots/tarnumMercenary.png",
+				"https://raw.githubusercontent.com/vcmi-mods/tarnum/vcmi-1.6/screenshots/asylum01.png",
+				"https://raw.githubusercontent.com/vcmi-mods/tarnum/vcmi-1.6/screenshots/tarnumPathfinder.png"
+			],
+			"downloadSize" : 5.603
+		},
+		"grove" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/grove/vcmi-1.6/Grove/mod.json",
+			"download" : "https://github.com/vcmi-mods/grove/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/grove/main/screenshots/screen1.png",
+				"https://raw.githubusercontent.com/vcmi-mods/grove/main/screenshots/screen2.png",
+				"https://raw.githubusercontent.com/vcmi-mods/grove/main/screenshots/screen3.png",
+				"https://raw.githubusercontent.com/vcmi-mods/grove/main/screenshots/screen4.png",
+				"https://raw.githubusercontent.com/vcmi-mods/grove/main/screenshots/screen5.png"
+			],
+			"downloadSize" : 19.507
+		},
+		"combine-grail" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/combine-grail/vcmi-1.6/combine-grail/mod.json",
+			"download" : "https://github.com/vcmi-mods/combine-grail/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/combine-grail/main/screenshots/screen1.png"
+			],
+			"downloadSize" : 0.505
+		},
+		"fairy-town" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/fairy-town/vcmi-1.6/fairy-town/mod.json",
+			"download" : "https://github.com/vcmi-mods/fairy-town/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/fairy-town/main/screenshots/screen1.png"
+			],
+			"downloadSize" : 21.595
+		},
+		"haven-town" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/haven-town/vcmi-1.6/haven-town/mod.json",
+			"download" : "https://github.com/vcmi-mods/haven-town/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/haven-town/vcmi-1.6/screenshots/screen1.png",
+				"https://raw.githubusercontent.com/vcmi-mods/haven-town/vcmi-1.6/screenshots/screen2.png",
+				"https://raw.githubusercontent.com/vcmi-mods/haven-town/vcmi-1.6/screenshots/screen3.png"
+			],
+			"downloadSize" : 14.682
+		},
+		"ruins-town" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/ruins-town/vcmi-1.6/ruins-town/mod.json",
+			"download" : "https://github.com/vcmi-mods/ruins-town/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/ruins-town/vcmi-1.6/screenshots/screen1.png",
+				"https://raw.githubusercontent.com/vcmi-mods/ruins-town/vcmi-1.6/screenshots/screen2.png",
+				"https://raw.githubusercontent.com/vcmi-mods/ruins-town/vcmi-1.6/screenshots/screen3.png",
+				"https://raw.githubusercontent.com/vcmi-mods/ruins-town/vcmi-1.6/screenshots/screen4.png",
+				"https://raw.githubusercontent.com/vcmi-mods/ruins-town/vcmi-1.6/screenshots/screen5.png",
+				"https://raw.githubusercontent.com/vcmi-mods/ruins-town/vcmi-1.6/screenshots/wiki1.png",
+				"https://raw.githubusercontent.com/vcmi-mods/ruins-town/vcmi-1.6/screenshots/wiki2.png",
+				"https://raw.githubusercontent.com/vcmi-mods/ruins-town/vcmi-1.6/screenshots/wiki3.png"
+			],
+			"downloadSize" : 29.21
+		},
+		"h3-themes" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/h3-themes/vcmi-1.6/h3-themes/mod.json",
+			"download" : "https://github.com/vcmi-mods/h3-themes/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/h3-themes/vcmi-1.5/screenshots/AB-menu.png",
+				"https://raw.githubusercontent.com/vcmi-mods/h3-themes/vcmi-1.5/screenshots/HotA-16-menu.png",
+				"https://raw.githubusercontent.com/vcmi-mods/h3-themes/vcmi-1.5/screenshots/HotA-17-menu.png",
+				"https://raw.githubusercontent.com/vcmi-mods/h3-themes/vcmi-1.5/screenshots/RoE-menu.png",
+				"https://raw.githubusercontent.com/vcmi-mods/h3-themes/vcmi-1.5/screenshots/SoD-menu.png",
+				"https://raw.githubusercontent.com/vcmi-mods/h3-themes/vcmi-1.5/screenshots/ToW-menu.png",
+				"https://raw.githubusercontent.com/vcmi-mods/h3-themes/vcmi-1.5/screenshots/WoG-menu.png"
+			],
+			"downloadSize" : 439.242
+		},
+		"creatures-hidden-potential" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/creatures-hidden-potential/vcmi-1.6/creatures-hidden-potential/mod.json",
+			"download" : "https://github.com/vcmi-mods/creatures-hidden-potential/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/creatures-hidden-potential/main/screenshots/screen1.png",
+				"https://raw.githubusercontent.com/vcmi-mods/creatures-hidden-potential/main/screenshots/screen2.png",
+				"https://raw.githubusercontent.com/vcmi-mods/creatures-hidden-potential/main/screenshots/screen3.png"
+			],
+			"downloadSize" : 3.518
+		},
+		"tartarus-town" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/tartarus-town/vcmi-1.6/tartarus-town/mod.json",
+			"download" : "https://github.com/vcmi-mods/tartarus-town/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/tartarus-town/main/screenshots/screen1.png",
+				"https://raw.githubusercontent.com/vcmi-mods/tartarus-town/main/screenshots/screen2.png",
+				"https://raw.githubusercontent.com/vcmi-mods/tartarus-town/main/screenshots/screen3.png",
+				"https://raw.githubusercontent.com/vcmi-mods/tartarus-town/main/screenshots/screen4.png",
+				"https://raw.githubusercontent.com/vcmi-mods/tartarus-town/main/screenshots/screen5.png",
+				"https://raw.githubusercontent.com/vcmi-mods/tartarus-town/main/screenshots/screen6.png"
+			],
+			"downloadSize" : 16.13
+		},
+		"preserve-town" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/preserve-town/vcmi-1.6/preserve/mod.json",
+			"download" : "https://github.com/vcmi-mods/preserve-town/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/preserve-town/main/screenshots/screen1.png",
+				"https://raw.githubusercontent.com/vcmi-mods/preserve-town/main/screenshots/screen2.png",
+				"https://raw.githubusercontent.com/vcmi-mods/preserve-town/main/screenshots/screen3.png",
+				"https://raw.githubusercontent.com/vcmi-mods/preserve-town/main/screenshots/screen4.png",
+				"https://raw.githubusercontent.com/vcmi-mods/preserve-town/main/screenshots/screen5.png",
+				"https://raw.githubusercontent.com/vcmi-mods/preserve-town/main/screenshots/screen6.png"
+			],
+			"downloadSize" : 21.539
+		},
+		"abyss-town" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/abyss-town/vcmi-1.6/abyss-town/mod.json",
+			"download" : "https://github.com/vcmi-mods/abyss-town/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/abyss-town/main/screenshots/screen1.png",
+				"https://raw.githubusercontent.com/vcmi-mods/abyss-town/main/screenshots/screen2.png",
+				"https://raw.githubusercontent.com/vcmi-mods/abyss-town/main/screenshots/screen3.png",
+				"https://raw.githubusercontent.com/vcmi-mods/abyss-town/main/screenshots/screen4.png",
+				"https://raw.githubusercontent.com/vcmi-mods/abyss-town/main/screenshots/screen5.png"
+			],
+			"downloadSize" : 32.814
+		},
+		"retreat-town" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/retreat-town/vcmi-1.6/retreat-town/mod.json",
+			"download" : "https://github.com/vcmi-mods/retreat-town/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/retreat-town/vcmi-1.6/screenshots/screen1.png",
+				"https://raw.githubusercontent.com/vcmi-mods/retreat-town/vcmi-1.6/screenshots/screen2.png",
+				"https://raw.githubusercontent.com/vcmi-mods/retreat-town/vcmi-1.6/screenshots/screen3.png"
+			],
+			"downloadSize" : 18.323
+		},
+		"cetatea-town" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/cetatea-town/vcmi-1.6/cetatea/mod.json",
+			"download" : "https://github.com/vcmi-mods/cetatea-town/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/cetatea-town/main/screenshots/screen1.png",
+				"https://raw.githubusercontent.com/vcmi-mods/cetatea-town/main/screenshots/screen2.png",
+				"https://raw.githubusercontent.com/vcmi-mods/cetatea-town/main/screenshots/screen3.png",
+				"https://raw.githubusercontent.com/vcmi-mods/cetatea-town/main/screenshots/screen4.png",
+				"https://raw.githubusercontent.com/vcmi-mods/cetatea-town/main/screenshots/screen5.png"
+			],
+			"downloadSize" : 14.451
+		},
+		"andruids-spell-balance" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/andruids-spell-balance/vcmi-1.6/andruids-spell-balance/mod.json",
+			"download" : "https://github.com/vcmi-mods/andruids-spell-balance/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/andruids-spell-balance/main/screenshots/screen1.png"
+			],
+			"downloadSize" : 0.811
+		},
+		"new-old-spells-plus" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/new-old-spells-plus/vcmi-1.6/newOldSpellsPlus/mod.json",
+			"download" : "https://github.com/vcmi-mods/new-old-spells-plus/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/new-old-spells-plus/main/screenshots/screen1.png"
+			],
+			"downloadSize" : 2.104
+		},
+		"portraits-packs" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/portraits-packs/vcmi-1.6/Portaits%20packs/mod.json",
+			"download" : "https://github.com/vcmi-mods/portraits-packs/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/portraits-packs/main/screenshots/screen1.png",
+				"https://raw.githubusercontent.com/vcmi-mods/portraits-packs/main/screenshots/screen2.png",
+				"https://raw.githubusercontent.com/vcmi-mods/portraits-packs/main/screenshots/screen3.png",
+				"https://raw.githubusercontent.com/vcmi-mods/portraits-packs/main/screenshots/screen4.png"
+			],
+			"downloadSize" : 18.601
+		},
+		"heroes-iii-orchestra" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/heroes-iii-orchestra/vcmi-1.6/Heroes%20III%20Orchestra/mod.json",
+			"download" : "https://github.com/vcmi-mods/heroes-iii-orchestra/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [],
+			"downloadSize" : 10.243
+		},
+		"russian-translation" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/mega-pack-rus/vcmi-1.6/russian-translation/mod.json",
+			"download" : "https://github.com/vcmi-mods/mega-pack-rus/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/mega-pack-rus/vcmi-1.6/screenshots/sc-1.png",
+				"https://raw.githubusercontent.com/vcmi-mods/mega-pack-rus/vcmi-1.6/screenshots/sc-2.png",
+				"https://raw.githubusercontent.com/vcmi-mods/mega-pack-rus/vcmi-1.6/screenshots/sc-3.png",
+				"https://raw.githubusercontent.com/vcmi-mods/mega-pack-rus/vcmi-1.6/screenshots/sc-4.png",
+				"https://raw.githubusercontent.com/vcmi-mods/mega-pack-rus/vcmi-1.6/screenshots/sc-5.png",
+				"https://raw.githubusercontent.com/vcmi-mods/mega-pack-rus/vcmi-1.6/screenshots/sc-6.png",
+				"https://raw.githubusercontent.com/vcmi-mods/mega-pack-rus/vcmi-1.6/screenshots/sc-7.png"
+			],
+			"downloadSize" : 38.779
+		},
+		"new-interface-mod" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/new-interface-mod/vcmi-1.6/New%20Interface%20Mod/mod.json",
+			"download" : "https://github.com/vcmi-mods/new-interface-mod/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/new-interface-mod/vcmi-1.6/screenshots/screen1.png",
+				"https://raw.githubusercontent.com/vcmi-mods/new-interface-mod/vcmi-1.6/screenshots/screen2.png",
+				"https://raw.githubusercontent.com/vcmi-mods/new-interface-mod/vcmi-1.6/screenshots/screen3.png",
+				"https://raw.githubusercontent.com/vcmi-mods/new-interface-mod/vcmi-1.6/screenshots/screen4.png",
+				"https://raw.githubusercontent.com/vcmi-mods/new-interface-mod/vcmi-1.6/screenshots/screen5.png",
+				"https://raw.githubusercontent.com/vcmi-mods/new-interface-mod/vcmi-1.6/screenshots/screen6.png",
+				"https://raw.githubusercontent.com/vcmi-mods/new-interface-mod/vcmi-1.6/screenshots/screen7.png"
+			],
+			"downloadSize" : 35.767
+		},
+		"medusa-mod" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/medusa-mod/refs/heads/main/Medusa%20Mod/mod.json",
+			"download" : "https://github.com/vcmi-mods/medusa-mod/archive/refs/heads/main.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/medusa-mod/refs/heads/main/Screenshots/Screenshot_20250105_010237.png",
+				"https://raw.githubusercontent.com/vcmi-mods/medusa-mod/refs/heads/main/Screenshots/Screenshot_20250105_010319.png",
+				"https://raw.githubusercontent.com/vcmi-mods/medusa-mod/refs/heads/main/Screenshots/Screenshot_20250105_010533.png"
+			],
+			"downloadSize" : 20.024
+		},
+		"hi-rez-menu" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/hi-rez-menu/vcmi-1.6/new-menu/mod.json",
+			"download" : "https://github.com/vcmi-mods/hi-rez-menu/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/hi-rez-menu/main/screenshots/screen1.png"
+			],
+			"downloadSize" : 8.12
+		},
+		"greenhouse-town" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/greenhouse-town/vcmi-1.6/Greenhouse/mod.json",
+			"download" : "https://github.com/vcmi-mods/greenhouse-town/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/greenhouse-town/main/screenshots/screen1.png",
+				"https://raw.githubusercontent.com/vcmi-mods/greenhouse-town/main/screenshots/screen2.png",
+				"https://raw.githubusercontent.com/vcmi-mods/greenhouse-town/main/screenshots/screen3.png",
+				"https://raw.githubusercontent.com/vcmi-mods/greenhouse-town/main/screenshots/screen4.png"
+			],
+			"downloadSize" : 14.227
+		},
+		"lotrd-townscreens" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/lotrd-townscreens/vcmi-1.6/lotrd-townscreens/mod.json",
+			"download" : "https://github.com/vcmi-mods/lotrd-townscreens/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 13.253
+		},
+		"boost-ai" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/boost-ai/vcmi-1.6/mod.json",
+			"download" : "https://github.com/vcmi-mods/boost-ai/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 0.008
+		},
+		"an-expansion" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/an-expansion/vcmi-1.6/mod.json",
+			"download" : "https://github.com/vcmi-mods/an-expansion/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 6.779
+		},
+		"refugee-town" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/refugee-town/vcmi-1.6/refugee-town/mod.json",
+			"download" : "https://github.com/vcmi-mods/refugee-town/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/refugee-town/vcmi-1.6/screenshots/screen1.png",
+				"https://raw.githubusercontent.com/vcmi-mods/refugee-town/vcmi-1.6/screenshots/screen2.png",
+				"https://raw.githubusercontent.com/vcmi-mods/refugee-town/vcmi-1.6/screenshots/screen3.png",
+				"https://raw.githubusercontent.com/vcmi-mods/refugee-town/vcmi-1.6/screenshots/screen4.png",
+				"https://raw.githubusercontent.com/vcmi-mods/refugee-town/vcmi-1.6/screenshots/screen5.png",
+				"https://raw.githubusercontent.com/vcmi-mods/refugee-town/vcmi-1.6/screenshots/screen7.png"
+			],
+			"downloadSize" : 34.503
+		},
+		"asphalt-terrain" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/asphalt-terrain/vcmi-1.6/asphalt-terrain/mod.json",
+			"download" : "https://github.com/vcmi-mods/asphalt-terrain/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/asphalt-terrain/vcmi-1.2/screenshots/screen01.png",
+				"https://raw.githubusercontent.com/vcmi-mods/asphalt-terrain/vcmi-1.2/screenshots/screen02.png"
+			],
+			"downloadSize" : 14.442
+		},
+		"newtown-terrains" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/newtown-terrains/vcmi-1.6/newtown-terrains/mod.json",
+			"download" : "https://github.com/vcmi-mods/newtown-terrains/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/newtown-terrains/vcmi-1.4/screenshots/screen10.png",
+				"https://raw.githubusercontent.com/vcmi-mods/newtown-terrains/vcmi-1.4/screenshots/screen11.png",
+				"https://raw.githubusercontent.com/vcmi-mods/newtown-terrains/vcmi-1.4/screenshots/screen12.png",
+				"https://raw.githubusercontent.com/vcmi-mods/newtown-terrains/vcmi-1.4/screenshots/screen13.png"
+			],
+			"downloadSize" : 51.157
+		},
+		"forge2k" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/forge2k/vcmi-1.6/Forge2k/mod.json",
+			"download" : "https://github.com/vcmi-mods/forge2k/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/forge2k/vcmi-1.5/screenshots/screen01.png",
+				"https://raw.githubusercontent.com/vcmi-mods/forge2k/vcmi-1.5/screenshots/screen02.png"
+			],
+			"downloadSize" : 21.837
+		},
+		"ab-bad-ending-assets" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/ab-bad-ending-assets/vcmi-1.6/AB Bad Ending Assets/mod.json",
+			"download" : "https://github.com/vcmi-mods/ab-bad-ending-assets/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/ab-bad-ending-assets/vcmi-1.4/screenshots/screen01.png",
+				"https://raw.githubusercontent.com/vcmi-mods/ab-bad-ending-assets/vcmi-1.4/screenshots/screen02.png"
+			],
+			"downloadSize" : 16.482
+		},
+		"ab-bad-ending-maps" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/ab-bad-ending-maps/vcmi-1.6/AB Bad Ending Maps/mod.json",
+			"download" : "https://github.com/vcmi-mods/ab-bad-ending-maps/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/ab-bad-ending-maps/vcmi-1.4/screenshots/screen01.png",
+				"https://raw.githubusercontent.com/vcmi-mods/ab-bad-ending-maps/vcmi-1.4/screenshots/screen02.png"
+			],
+			"downloadSize" : 1.342
+		},
+		"warzyw-templates" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/warzyw-templates/vcmi-1.6/warzyw-templates/mod.json",
+			"download" : "https://github.com/vcmi-mods/warzyw-templates/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 0.127
+		},
+		"ensrick-portraits" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/ensrick-portraits/vcmi-1.6/ensrick-portraits/mod.json",
+			"download" : "https://github.com/vcmi-mods/ensrick-portraits/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/ensrick-portraits/main/screenshots/screen01.png",
+				"https://raw.githubusercontent.com/vcmi-mods/ensrick-portraits/main/screenshots/screen02.png"
+			],
+			"downloadSize" : 12.269
+		},
+		"morns-battlefields" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/morns-battlefields/vcmi-1.6/morns-battlefields/mod.json",
+			"download" : "https://github.com/vcmi-mods/morns-battlefields/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/morns-battlefields/vcmi-1.4/screenshots/01.png"
+			],
+			"downloadSize" : 23.788
+		},
+		"towns-new-views" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/towns-new-views/vcmi-1.6/towns-new-views/mod.json",
+			"download" : "https://github.com/vcmi-mods/towns-new-views/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/towns-new-views/vcmi-1.2/screenshots/screen1.png",
+				"https://raw.githubusercontent.com/vcmi-mods/towns-new-views/vcmi-1.2/screenshots/screen2.png",
+				"https://raw.githubusercontent.com/vcmi-mods/towns-new-views/vcmi-1.2/screenshots/screen3.png",
+				"https://raw.githubusercontent.com/vcmi-mods/towns-new-views/vcmi-1.2/screenshots/screen4.png"
+			],
+			"downloadSize" : 3.257
+		},
+		"campaings-pack" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/campaings-pack/vcmi-1.6/campaings-pack/mod.json",
+			"download" : "https://github.com/vcmi-mods/campaings-pack/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/campaings-pack/vcmi-1.3/screenshots/screen01.png"
+			],
+			"downloadSize" : 11.223
+		},
+		"dydzios-map-pack" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/dydzios-map-pack/vcmi-1.6/dydzios-map-pack/mod.json",
+			"download" : "https://github.com/vcmi-mods/dydzios-map-pack/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 54.304
+		},
+		"h3-campaigns-remade" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/h3-campaigns-remade/vcmi-1.6/h3-campaigns-remade/mod.json",
+			"download" : "https://github.com/vcmi-mods/h3-campaigns-remade/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/h3-campaigns-remade/vcmi-1.3/screenshots/screen01.png",
+				"https://raw.githubusercontent.com/vcmi-mods/h3-campaigns-remade/vcmi-1.3/screenshots/screen02.png",
+				"https://raw.githubusercontent.com/vcmi-mods/h3-campaigns-remade/vcmi-1.3/screenshots/screen03.png"
+			],
+			"downloadSize" : 5.915
+		},
+		"zefix" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/zefix/vcmi-1.6/ZEfix/mod.json",
+			"download" : "https://github.com/vcmi-mods/zefix/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 0.002
+		},
+		"adventure-spells-pack" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/adventure-spells-pack/vcmi-1.6/adventure-spells-pack/mod.json",
+			"download" : "https://github.com/vcmi-mods/adventure-spells-pack/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/adventure-spells-pack/vcmi-1.6/screenshots/screen01.png",
+				"https://raw.githubusercontent.com/vcmi-mods/adventure-spells-pack/vcmi-1.6/screenshots/screen02.png",
+				"https://raw.githubusercontent.com/vcmi-mods/adventure-spells-pack/vcmi-1.6/screenshots/screen03.png",
+				"https://raw.githubusercontent.com/vcmi-mods/adventure-spells-pack/vcmi-1.6/screenshots/screen04.png",
+				"https://raw.githubusercontent.com/vcmi-mods/adventure-spells-pack/vcmi-1.6/screenshots/screen05.png"
+			],
+			"downloadSize" : 3.244
+		},
+		"third-upgrades" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/third-upgrades/vcmi-1.6/third-upgrades/mod.json",
+			"download" : "https://github.com/vcmi-mods/third-upgrades/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/third-upgrades/vcmi-1.4/screenshots/screen01.png",
+				"https://raw.githubusercontent.com/vcmi-mods/third-upgrades/vcmi-1.4/screenshots/screen02.png",
+				"https://raw.githubusercontent.com/vcmi-mods/third-upgrades/vcmi-1.4/screenshots/screen03.png",
+				"https://raw.githubusercontent.com/vcmi-mods/third-upgrades/vcmi-1.4/screenshots/screen04.png"
+			],
+			"downloadSize" : 35.604
+		},
+		"mighty-heroes-iii" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/mighty-heroes-iii/vcmi-1.6/mighty-heroes-iii/mod.json",
+			"download" : "https://github.com/vcmi-mods/mighty-heroes-iii/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/mighty-heroes-iii/vcmi-1.4/screenshots/01.png",
+				"https://raw.githubusercontent.com/vcmi-mods/mighty-heroes-iii/vcmi-1.4/screenshots/02.png",
+				"https://raw.githubusercontent.com/vcmi-mods/mighty-heroes-iii/vcmi-1.4/screenshots/03.png"
+			],
+			"downloadSize" : 19.214
+		},
+		"erathian-font" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/erathian-font/vcmi-1.6/erathian-font/mod.json",
+			"download" : "https://github.com/vcmi-mods/erathian-font/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/erathian-font/vcmi-1.6/screenshots/screen1.png",
+				"https://raw.githubusercontent.com/vcmi-mods/erathian-font/vcmi-1.6/screenshots/screen2.png",
+				"https://raw.githubusercontent.com/vcmi-mods/erathian-font/vcmi-1.6/screenshots/screen3.png"
+			],
+			"downloadSize" : 2.449
+		},
+		"kartenarchiv" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/kartenarchiv-mappack/vcmi-1.6/kartenarchiv/mod.json",
+			"download" : "https://github.com/vcmi-mods/kartenarchiv-mappack/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 71.573
+		},
+		"vampires-only-gameplay-enhancements" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/vampires-only-gameplay-enhancements/vcmi-1.6/vampiresOnlyGameplayEnhancements/mod.json",
+			"download" : "https://github.com/vcmi-mods/vampires-only-gameplay-enhancements/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 3.204
+		},
+		"farriery-town" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/farriery-town/vcmi-1.6/farriery-town/mod.json",
+			"download" : "https://github.com/vcmi-mods/farriery-town/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/farriery-town/vcmi-1.6/Screenshots/buildings.png",
+				"https://raw.githubusercontent.com/vcmi-mods/farriery-town/vcmi-1.6/Screenshots/Dragon Utopia.png",
+				"https://raw.githubusercontent.com/vcmi-mods/farriery-town/vcmi-1.6/Screenshots/Farriery-town-and-lineup.png",
+				"https://raw.githubusercontent.com/vcmi-mods/farriery-town/vcmi-1.6/Screenshots/lineup.png",
+				"https://raw.githubusercontent.com/vcmi-mods/farriery-town/vcmi-1.6/Screenshots/Spoiled Land.png",
+				"https://raw.githubusercontent.com/vcmi-mods/farriery-town/vcmi-1.6/screenshots/screen06.png"
+			],
+			"downloadSize" : 34.733
+		},
+		"h3Evo" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/H3Evo/vcmi-1.6/mod.json",
+			"download" : "https://github.com/vcmi-mods/H3Evo/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/H3Evo/main/Screenshots/Adventure Map.png",
+				"https://raw.githubusercontent.com/vcmi-mods/H3Evo/main/Screenshots/Instalation 1 - Needed WoG Submods.png",
+				"https://raw.githubusercontent.com/vcmi-mods/H3Evo/main/Screenshots/Instalation 2 - Needed ToW Submods.png",
+				"https://raw.githubusercontent.com/vcmi-mods/H3Evo/main/Screenshots/Instalation 3 - Needed Andruids Expansion Submods.png",
+				"https://raw.githubusercontent.com/vcmi-mods/H3Evo/main/Screenshots/ToW alternate creatures - Tower Build Screen.png",
+				"https://raw.githubusercontent.com/vcmi-mods/H3Evo/main/Screenshots/ToW alternate creatures - Tower Overview.png",
+				"https://raw.githubusercontent.com/vcmi-mods/H3Evo/main/Screenshots/ToW alternate creatures - Tower Recruting Screen.png"
+			],
+			"downloadSize" : 7.627
+		},
+		"small-era-mods" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/small-era-mods/vcmi-1.6/small-era-mods/mod.json",
+			"download" : "https://github.com/vcmi-mods/small-era-mods/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 16.098
+		},
+		"phoenix-as-a-dream" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/phoenix-as-a-dream/vcmi-1.6/mod.json",
+			"download" : "https://github.com/vcmi-mods/phoenix-as-a-dream/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 7.726
+		},
+		"extreme-ai" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/extreme-ai/vcmi-1.6/extreme-ai/mod.json",
+			"download" : "https://github.com/vcmi-mods/extreme-ai/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 0.003
+		},
+		"object-pack" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/object-pack/vcmi-1.6/object-pack/mod.json",
+			"download" : "https://github.com/vcmi-mods/object-pack/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/object-pack/vcmi-1.6/screenshots/screen01.png",
+				"https://raw.githubusercontent.com/vcmi-mods/object-pack/vcmi-1.6/screenshots/screen02.png",
+				"https://raw.githubusercontent.com/vcmi-mods/object-pack/vcmi-1.6/screenshots/screen03.png",
+				"https://raw.githubusercontent.com/vcmi-mods/object-pack/vcmi-1.6/screenshots/screen04.png",
+				"https://raw.githubusercontent.com/vcmi-mods/object-pack/vcmi-1.6/screenshots/screen05.png",
+				"https://raw.githubusercontent.com/vcmi-mods/object-pack/vcmi-1.6/screenshots/screen06.png",
+				"https://raw.githubusercontent.com/vcmi-mods/object-pack/vcmi-1.6/screenshots/screen07.png"
+			],
+			"downloadSize" : 6.406
+		},
+		"tavern-invite" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/tavern-invite/vcmi-1.6/mod.json",
+			"download" : "https://github.com/vcmi-mods/tavern-invite/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 0.001
+		},
+		"ultimate-balance" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/simple-game-balance/vcmi-1.6/mod.json",
+			"download" : "https://github.com/vcmi-mods/simple-game-balance/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 0.01
+		},
+		"graphics-balance-music" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/graphics-balance-music/vcmi-1.6/graphics-balance-music/mod.json",
+			"download" : "https://github.com/vcmi-mods/graphics-balance-music/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 78.105
+		},
+		"new-summon-spells" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/new-summon-spells/vcmi-1.6/new-summon-spells/mod.json",
+			"download" : "https://github.com/vcmi-mods/new-summon-spells/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/new-summon-spells/vcmi-1.5/screenshots/screen1.png",
+				"https://raw.githubusercontent.com/vcmi-mods/new-summon-spells/vcmi-1.5/screenshots/screen2.png",
+				"https://raw.githubusercontent.com/vcmi-mods/new-summon-spells/vcmi-1.5/screenshots/screen3.png",
+				"https://raw.githubusercontent.com/vcmi-mods/new-summon-spells/vcmi-1.5/screenshots/screen4.png",
+				"https://raw.githubusercontent.com/vcmi-mods/new-summon-spells/vcmi-1.5/screenshots/screen5.png"
+			],
+			"downloadSize" : 4.212
+		},
+		"witchking-artifacts" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/witchking-artifacts/vcmi-1.6/witchking-artifacts/mod.json",
+			"download" : "https://github.com/vcmi-mods/witchking-artifacts/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/witchking-artifacts/vcmi-1.5/screenshots/screen1.png",
+				"https://raw.githubusercontent.com/vcmi-mods/witchking-artifacts/vcmi-1.5/screenshots/screen2.png",
+				"https://raw.githubusercontent.com/vcmi-mods/witchking-artifacts/vcmi-1.5/screenshots/screen3.png",
+				"https://raw.githubusercontent.com/vcmi-mods/witchking-artifacts/vcmi-1.5/screenshots/screen4.png",
+				"https://raw.githubusercontent.com/vcmi-mods/witchking-artifacts/vcmi-1.5/screenshots/screen5.png",
+				"https://raw.githubusercontent.com/vcmi-mods/witchking-artifacts/vcmi-1.5/screenshots/screen6.png",
+				"https://raw.githubusercontent.com/vcmi-mods/witchking-artifacts/vcmi-1.5/screenshots/screen7.png",
+				"https://raw.githubusercontent.com/vcmi-mods/witchking-artifacts/vcmi-1.5/screenshots/screen8.png",
+				"https://raw.githubusercontent.com/vcmi-mods/witchking-artifacts/vcmi-1.5/screenshots/screen9.png",
+				"https://raw.githubusercontent.com/vcmi-mods/witchking-artifacts/vcmi-1.5/screenshots/screen10.png",
+				"https://raw.githubusercontent.com/vcmi-mods/witchking-artifacts/vcmi-1.5/screenshots/screen11.png",
+				"https://raw.githubusercontent.com/vcmi-mods/witchking-artifacts/vcmi-1.5/screenshots/screen12.png",
+				"https://raw.githubusercontent.com/vcmi-mods/witchking-artifacts/vcmi-1.5/screenshots/screen13.png"
+			],
+			"downloadSize" : 8.755
+		},
+		"moon-artifacts" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/moon-artifacts/vcmi-1.6/moon-artifacts/mod.json",
+			"download" : "https://github.com/vcmi-mods/moon-artifacts/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/moon-artifacts/vcmi-1.5/screenshots/screen1.png",
+				"https://raw.githubusercontent.com/vcmi-mods/moon-artifacts/vcmi-1.5/screenshots/screen2.png",
+				"https://raw.githubusercontent.com/vcmi-mods/moon-artifacts/vcmi-1.5/screenshots/screen3.png",
+				"https://raw.githubusercontent.com/vcmi-mods/moon-artifacts/vcmi-1.5/screenshots/screen4.png",
+				"https://raw.githubusercontent.com/vcmi-mods/moon-artifacts/vcmi-1.5/screenshots/screen5.png",
+				"https://raw.githubusercontent.com/vcmi-mods/moon-artifacts/vcmi-1.5/screenshots/screen6.png"
+			],
+			"downloadSize" : 2.391
+		},
+		"factory-creatures" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/factory-creatures/vcmi-1.6/factory-creatures/mod.json",
+			"download" : "https://github.com/vcmi-mods/factory-creatures/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/factory-creatures/vcmi-1.5/screenshots/screen1.png",
+				"https://raw.githubusercontent.com/vcmi-mods/factory-creatures/vcmi-1.5/screenshots/screen2.png",
+				"https://raw.githubusercontent.com/vcmi-mods/factory-creatures/vcmi-1.5/screenshots/screen3.png",
+				"https://raw.githubusercontent.com/vcmi-mods/factory-creatures/vcmi-1.5/screenshots/screen4.png"
+			],
+			"downloadSize" : 38.302
+		},
+		"luk3Z-templates-pack" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/luk3Z-templates-pack/vcmi-1.6/luk3Z-templates-pack/mod.json",
+			"download" : "https://github.com/vcmi-mods/luk3Z-templates-pack/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/luk3Z-templates-pack/vcmi-1.5/screenshots/screen1.png",
+				"https://raw.githubusercontent.com/vcmi-mods/luk3Z-templates-pack/vcmi-1.5/screenshots/screen2.png",
+				"https://raw.githubusercontent.com/vcmi-mods/luk3Z-templates-pack/vcmi-1.5/screenshots/screen3.png",
+				"https://raw.githubusercontent.com/vcmi-mods/luk3Z-templates-pack/vcmi-1.5/screenshots/screen4.png",
+				"https://raw.githubusercontent.com/vcmi-mods/luk3Z-templates-pack/vcmi-1.5/screenshots/screen5.png",
+				"https://raw.githubusercontent.com/vcmi-mods/luk3Z-templates-pack/vcmi-1.5/screenshots/screen6.png",
+				"https://raw.githubusercontent.com/vcmi-mods/luk3Z-templates-pack/vcmi-1.5/screenshots/screen7.png"
+			],
+			"downloadSize" : 13.013
+		},
+		"new-monsters-pack" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/new-monsters-pack/vcmi-1.6/new-monsters-pack/mod.json",
+			"download" : "https://github.com/vcmi-mods/new-monsters-pack/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/new-monsters-pack/vcmi-1.6/screenshots/screen01.png",
+				"https://raw.githubusercontent.com/vcmi-mods/new-monsters-pack/vcmi-1.6/screenshots/screen02.png",
+				"https://raw.githubusercontent.com/vcmi-mods/new-monsters-pack/vcmi-1.6/screenshots/screen03.png",
+				"https://raw.githubusercontent.com/vcmi-mods/new-monsters-pack/vcmi-1.6/screenshots/screen04.png",
+				"https://raw.githubusercontent.com/vcmi-mods/new-monsters-pack/vcmi-1.6/screenshots/screen05.png",
+				"https://raw.githubusercontent.com/vcmi-mods/new-monsters-pack/vcmi-1.6/screenshots/screen06.png",
+				"https://raw.githubusercontent.com/vcmi-mods/new-monsters-pack/vcmi-1.6/screenshots/screen07.png",
+				"https://raw.githubusercontent.com/vcmi-mods/new-monsters-pack/vcmi-1.6/screenshots/screen08.png",
+				"https://raw.githubusercontent.com/vcmi-mods/new-monsters-pack/vcmi-1.6/screenshots/screen09.png",
+				"https://raw.githubusercontent.com/vcmi-mods/new-monsters-pack/vcmi-1.6/screenshots/screen10.png"
+			],
+			"downloadSize" : 191.112
+		},
+		"czech-map-pack" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/czech-map-pack/vcmi-1.6/czech-map-pack/mod.json",
+			"download" : "https://github.com/vcmi-mods/czech-map-pack/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 13.225
+		},
+		"modder-tools-pack" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/modder-tools-pack/main/modder-tools-pack/mod.json",
+			"download" : "https://github.com/vcmi-mods/modder-tools-pack/archive/refs/heads/main.zip",
+			"downloadSize" : 70.098
+		},
+		"heroes-o-pedia" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/heroes-o-pedia/vcmi-1.6/heroes-o-pedia/mod.json",
+			"download" : "https://github.com/vcmi-mods/heroes-o-pedia/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/heroes-o-pedia/vcmi-1.6/screenshots/screen01.png",
+				"https://raw.githubusercontent.com/vcmi-mods/heroes-o-pedia/vcmi-1.6/screenshots/screen02.png",
+				"https://raw.githubusercontent.com/vcmi-mods/heroes-o-pedia/vcmi-1.6/screenshots/screen03.png"
+			],
+			"downloadSize" : 3.501
+		},
+		"chronicles-enhanced" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/chronicles-enhanced/vcmi-1.6/chronicles-enhanced/mod.json",
+			"download" : "https://github.com/vcmi-mods/chronicles-enhanced/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/chronicles-enhanced/vcmi-1.6/screenshots/screen01.png",
+				"https://raw.githubusercontent.com/vcmi-mods/chronicles-enhanced/vcmi-1.6/screenshots/screen02.png",
+				"https://raw.githubusercontent.com/vcmi-mods/chronicles-enhanced/vcmi-1.6/screenshots/screen03.png"
+			],
+			"downloadSize" : 5.77
+		},
+		"overall-ai-bonus" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/overall-ai-bonus/vcmi-1.6/overall-ai-bonus/mod.json",
+			"download" : "https://github.com/vcmi-mods/overall-ai-bonus/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 0.063
+		},
+		"vivid-battlefields" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/vivid-battlefields/vcmi-1.6/vivid-battlefields/mod.json",
+			"download" : "https://github.com/vcmi-mods/vivid-battlefields/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/vivid-battlefields/vcmi-1.6/screenshots/screen01.png",
+				"https://raw.githubusercontent.com/vcmi-mods/vivid-battlefields/vcmi-1.6/screenshots/screen02.png",
+				"https://raw.githubusercontent.com/vcmi-mods/vivid-battlefields/vcmi-1.6/screenshots/screen03.png",
+				"https://raw.githubusercontent.com/vcmi-mods/vivid-battlefields/vcmi-1.6/screenshots/screen04.png"
+			],
+			"downloadSize" : 34.905
+		},
+		"fused-artifacts" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/fused-artifacts/main/fused-artifacts/mod.json",
+			"download" : "https://github.com/vcmi-mods/fused-artifacts/archive/refs/heads/main.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/fused-artifacts/main/screenshots/screen01.png"
+			],
+			"downloadSize" : 0.924
+		},
+		"immortal-cultivation-heroes" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/immortal-cultivation-heroes/vcmi-1.6/lmods/mod.json",
+			"download" : "https://github.com/vcmi-mods/immortal-cultivation-heroes/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/immortal-cultivation-heroes/vcmi-1.6/screenshots/screen1.png",
+				"https://raw.githubusercontent.com/vcmi-mods/immortal-cultivation-heroes/vcmi-1.6/screenshots/screen2.png",
+				"https://raw.githubusercontent.com/vcmi-mods/immortal-cultivation-heroes/vcmi-1.6/screenshots/screen3.png"
+			],
+			"downloadSize" : 21.928
+		},
+		"heroes3-extended-soundtrack" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/heroes3-extended-soundtrack/main/mod.json",
+			"download" : "https://github.com/vcmi-mods/heroes3-extended-soundtrack/archive/refs/heads/main.zip",
+			"downloadSize" : 248.28
+		},
+		"hq-music" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/hq-music/main/mod.json",
+			"download" : "https://github.com/vcmi-mods/hq-music/archive/refs/heads/main.zip",
+			"downloadSize" : 227.359
+		},
+		"new-sfx-sounds" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/new-sfx-sounds/main/mod.json",
+			"download" : "https://github.com/vcmi-mods/new-sfx-sounds/archive/refs/heads/main.zip",
+			"downloadSize" : 51.239
+		},
+		"alternate-townscreens" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/alternate-townscreens/vcmi-1.6/alternate-townscreens/mod.json",
+			"download" : "https://github.com/vcmi-mods/alternate-townscreens/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 60.409
+		},
+		"a-song-of-ice-and-fire" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/a-song-of-ice-and-fire/main/a-song-of-ice-and-fire/mod.json",
+			"download" : "https://github.com/vcmi-mods/a-song-of-ice-and-fire/archive/refs/heads/main.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/a-song-of-ice-and-fire/main/screenshots/screen1.png",
+				"https://raw.githubusercontent.com/vcmi-mods/a-song-of-ice-and-fire/main/screenshots/screen2.png",
+				"https://raw.githubusercontent.com/vcmi-mods/a-song-of-ice-and-fire/main/screenshots/screen3.png"
+			],
+			"downloadSize" : 10.694
+		},
+		"movement-arrows" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/movement-arrows/main/mod.json",
+			"download" : "https://github.com/vcmi-mods/movement-arrows/archive/refs/heads/main.zip",
+			"downloadSize" : 0.1
+		},
+		"ark-town" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/ark-town/vcmi-1.6/ark-town/mod.json",
+			"download" : "https://github.com/vcmi-mods/ark-town/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/ark-town/vcmi-1.6/screenshots/screen1.png",
+				"https://raw.githubusercontent.com/vcmi-mods/ark-town/vcmi-1.6/screenshots/screen2.png"
+			],
+			"downloadSize" : 16.487
+		},
+		"kremlin-town" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/kremlin-town/vcmi-1.6/kremlin-town/mod.json",
+			"download" : "https://github.com/vcmi-mods/kremlin-town/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/kremlin-town/vcmi-1.6/screenshots/screen1.png",
+				"https://raw.githubusercontent.com/vcmi-mods/kremlin-town/vcmi-1.6/screenshots/screen2.png",
+				"https://raw.githubusercontent.com/vcmi-mods/kremlin-town/vcmi-1.6/screenshots/screen3.png",
+				"https://raw.githubusercontent.com/vcmi-mods/kremlin-town/vcmi-1.6/screenshots/screen4.png",
+				"https://raw.githubusercontent.com/vcmi-mods/kremlin-town/vcmi-1.6/screenshots/screen5.png"
+			],
+			"downloadSize" : 46.627
+		},
+		"ai-disable-speedups" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/ai-disable-speedups/vcmi-1.6/mod.json",
+			"download" : "https://github.com/vcmi-mods/ai-disable-speedups/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 0.002
+		},
+		"new-skills-pack" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/new-skills-pack/main/new-skills-pack/mod.json",
+			"download" : "https://github.com/vcmi-mods/new-skills-pack/archive/refs/heads/main.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/new-skills-pack/main/ScreenShots/Basic Skills.bmp",
+				"https://raw.githubusercontent.com/vcmi-mods/new-skills-pack/main/ScreenShots/Heroes.bmp"
+			],
+			"downloadSize" : 3.293
+		},
+		"custom-templates" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/custom-templates/vcmi-1.6/custom-templates/mod.json",
+			"download" : "https://github.com/vcmi-mods/custom-templates/archive/refs/heads/vcmi-1.6.zip",
+			"screenshots" : [
+				"https://raw.githubusercontent.com/vcmi-mods/custom-templates/vcmi-1.6/screenshots/screen1.png"
+			],
+			"downloadSize" : 0.858
+		},
+		"cheat-mod" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/cheat-mod/vcmi-1.6/cheat-mod/mod.json",
+			"download" : "https://github.com/vcmi-mods/cheat-mod/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 0.004
+		},
+		"equal-stats" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/equal-stats/vcmi-1.6/equal-stats/mod.json",
+			"download" : "https://github.com/vcmi-mods/equal-stats/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 0.012
+		},
+		"chinese-maps-collection" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/chinese-maps-collection/main/chinese-maps-collection/mod.json",
+			"download" : "https://github.com/vcmi-mods/chinese-maps-collection/archive/refs/heads/main.zip",
+			"downloadSize" : 104.996
+		},
+		"pvp-balance" : {
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/pvp-balance/vcmi-1.6/mod.json",
+			"download" : "https://github.com/vcmi-mods/pvp-balance/archive/refs/heads/vcmi-1.6.zip",
+			"downloadSize" : 8.99
+		}
+	}
+}


### PR DESCRIPTION
All mods use vcmi-1.6 branch, with exception of vcmi-extras which now got 1.7 branch.

To be merged alongside with https://github.com/vcmi/vcmi/pull/5414

Format is a little bit different:
```jsonc
{
    "availableMods" : { 
        // list of mods, as before
    }
}
```
This should allow extensions to mod repository format, for example to mark removed / deprecated mods.