### PR TITLE
Update Kremlin screenshots

### DIFF
--- a/vcmi-1.6.json
+++ b/vcmi-1.6.json
@@ -970,7 +970,7 @@
 			"https://raw.githubusercontent.com/vcmi-mods/kremlin-town/vcmi-1.6/screenshots/screen2.png",
 			"https://raw.githubusercontent.com/vcmi-mods/kremlin-town/vcmi-1.6/screenshots/screen3.png",
 			"https://raw.githubusercontent.com/vcmi-mods/kremlin-town/vcmi-1.6/screenshots/screen4.png",
-			"https://raw.githubusercontent.com/vcmi-mods/kremlin-town/vcmi-1.6/screenshots/screen5.png"
+			"https://raw.githubusercontent.com/vcmi-mods/kremlin-town/vcmi-1.6/screenshots/screen6.png"
 		],
 		"downloadSize" : 46.636
 	},


### PR DESCRIPTION
When I try to replace the old screen5 with new one (i.e. delete old and add new), GitHub keeps the old one for some reason. Added the new one as screen6.png at the moment.