### PR TITLE
Removed warzyw-templates from 1.7 mod list

### DIFF
--- a/vcmi-1.7.json
+++ b/vcmi-1.7.json
@@ -583,11 +583,6 @@
 			],
 			"downloadSize" : 1.342
 		},
-		"warzyw-templates" : {
-			"mod" : "https://raw.githubusercontent.com/vcmi-mods/warzyw-templates/vcmi-1.6/warzyw-templates/mod.json",
-			"download" : "https://github.com/vcmi-mods/warzyw-templates/archive/refs/heads/vcmi-1.6.zip",
-			"downloadSize" : 0.127
-		},
 		"ensrick-portraits" : {
 			"mod" : "https://raw.githubusercontent.com/vcmi-mods/ensrick-portraits/vcmi-1.6/ensrick-portraits/mod.json",
 			"download" : "https://github.com/vcmi-mods/ensrick-portraits/archive/refs/heads/vcmi-1.6.zip",


### PR DESCRIPTION
All templates from that mod have been moved to either custom-templates (Grond, Sim City)
or pvp-balance (Brawl, Nowa Arena)
with improved structure, such as highly template-specific global changes are only in submods disabled by default so that players don't accidentally enable them when they want to play something else

