### PR TITLE
Add 1.5 and 1.6 to ignore list for updating sizes and stars

### DIFF
--- a/.github/ignore_json.py
+++ b/.github/ignore_json.py
@@ -1,1 +1,1 @@
-ignore = [ "./github.json", "./vcmi-1.2.json", "./vcmi-1.3.json", "./vcmi-1.4.json" ]
+ignore = [ "./github.json", "./vcmi-1.2.json", "./vcmi-1.3.json", "./vcmi-1.4.json", "./vcmi-1.5.json", "./vcmi-1.6.json" ]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,6 +78,6 @@ jobs:
         uses: EndBug/add-and-commit@v9
         with:
           default_author: github_actions
-          message: Update sizes
+          message: Update sizes and stars
           add: '*.json'
           push: --force


### PR DESCRIPTION
Add 1.5 and 1.6 to ignore list for updating sizes and stars... to speedup CI

@misiokles Can merged directly. I guess no one updates 1.6 mods in the next days (before 1.7 release). And even if - nothing bad happens.