### PR TITLE
Add download from released package

### DIFF
--- a/vcmi-1.7.json
+++ b/vcmi-1.7.json
@@ -917,7 +917,7 @@
 		},
 		"small-era-mods" : {
 			"mod" : "https://raw.githubusercontent.com/vcmi-mods/small-era-mods/vcmi-1.7/small-era-mods/mod.json",
-			"download" : "https://github.com/vcmi-mods/small-era-mods/archive/refs/heads/vcmi-1.7.zip",
+			"download" : "https://github.com/vcmi-mods/small-era-mods/releases/download/vcmi-1.7/vcmi-1.7.zip",
 			"downloadSize" : 32.116,
 			"githubStars" : 2,
 			"screenshots" : [

--- a/vcmi-1.7.json
+++ b/vcmi-1.7.json
@@ -916,7 +916,7 @@
 			"githubStars" : 0
 		},
 		"small-era-mods" : {
-			"mod" : "https://raw.githubusercontent.com/vcmi-mods/small-era-mods/vcmi-1.7/small-era-mods/mod.json",
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/small-era-mods/vcmi-1.7/mod.json",
 			"download" : "https://github.com/vcmi-mods/small-era-mods/releases/download/vcmi-1.7/vcmi-1.7.zip",
 			"downloadSize" : 32.116,
 			"githubStars" : 2,


### PR DESCRIPTION
To be merged after https://github.com/vcmi-mods/small-era-mods/pull/17 is merged and job succesfully create relase package.

Should work, but just want to be safe, before we turn HotA 1.8.0 into same logic