### PR TITLE
Fix Small ERA mods download link

### DIFF
--- a/vcmi-1.7.json
+++ b/vcmi-1.7.json
@@ -917,7 +917,7 @@
 		},
 		"small-era-mods" : {
 			"mod" : "https://raw.githubusercontent.com/vcmi-mods/small-era-mods/vcmi-1.7/mod.json",
-			"download" : "https://github.com/vcmi-mods/small-era-mods/releases/download/vcmi-1.7/vcmi-1.7.zip",
+			"download" : "https://github.com/vcmi-mods/small-era-mods/releases/download/vcmi-1.7/small-era-mods-vcmi-1.7.zip",
 			"downloadSize" : 32.016,
 			"githubStars" : 2,
 			"screenshots" : [


### PR DESCRIPTION
To be merged after: https://github.com/vcmi-mods/small-era-mods/pull/18

Example of new link
https://github.com/vcmi-mods/[modRepoName]/releases/download/[branchRepoName]/[modRepoName]-[branchRepoName].zip