### PR TITLE
HotA links update

### DIFF
--- a/vcmi-1.7.json
+++ b/vcmi-1.7.json
@@ -7,8 +7,8 @@
 			"githubStars" : 23
 		},
 		"hota" : {
-			"mod" : "https://raw.githubusercontent.com/vcmi-mods/horn-of-the-abyss/vcmi-1.7/hota/mod.json",
-			"download" : "https://github.com/vcmi-mods/horn-of-the-abyss/archive/refs/heads/vcmi-1.7.zip",
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/horn-of-the-abyss/vcmi-1.7/mod.json",
+			"download" : "https://github.com/vcmi-mods/horn-of-the-abyss/releases/download/vcmi-1.7/horn-of-the-abyss-vcmi-1.7.zip",
 			"screenshots" : [
 				"https://raw.githubusercontent.com/vcmi-mods/horn-of-the-abyss/vcmi-1.7/screenshots/01.png",
 				"https://raw.githubusercontent.com/vcmi-mods/horn-of-the-abyss/vcmi-1.7/screenshots/02.png",

--- a/vcmi-1.7.json
+++ b/vcmi-1.7.json
@@ -24,8 +24,7 @@
 				"https://raw.githubusercontent.com/vcmi-mods/horn-of-the-abyss/vcmi-1.7/screenshots/wiki3.png"
 			],
 			"downloadSize" : 246.063,
-			"githubStars" : 65,
-			"descriptionURL" : "https://raw.githubusercontent.com/vcmi-mods/horn-of-the-abyss/vcmi-1.7/hota/description.md"
+			"githubStars" : 65
 		},
 		"wake-of-gods" : {
 			"mod" : "https://raw.githubusercontent.com/vcmi-mods/wake-of-gods/vcmi-1.7/mod.json",
@@ -127,7 +126,7 @@
 				"https://raw.githubusercontent.com/vcmi-mods/new-pavilion/vcmi-1.7/screenshots/screen6.png",
 				"https://raw.githubusercontent.com/vcmi-mods/new-pavilion/vcmi-1.7/screenshots/screen7.png"
 			],
-			"downloadSize" : 62.365,
+			"downloadSize" : 42.978,
 			"githubStars" : 16
 		},
 		"cathedral-town" : {

--- a/vcmi-1.8.json
+++ b/vcmi-1.8.json
@@ -7,8 +7,8 @@
 			"githubStars" : 23
 		},
 		"hota" : {
-			"mod" : "https://raw.githubusercontent.com/vcmi-mods/horn-of-the-abyss/vcmi-1.7/hota/mod.json",
-			"download" : "https://github.com/vcmi-mods/horn-of-the-abyss/archive/refs/heads/vcmi-1.7.zip",
+			"mod" : "https://raw.githubusercontent.com/vcmi-mods/horn-of-the-abyss/vcmi-1.7/mod.json",
+			"download" : "https://github.com/vcmi-mods/horn-of-the-abyss/releases/download/vcmi-1.7/horn-of-the-abyss-vcmi-1.7.zip",
 			"screenshots" : [
 				"https://raw.githubusercontent.com/vcmi-mods/horn-of-the-abyss/vcmi-1.7/screenshots/01.png",
 				"https://raw.githubusercontent.com/vcmi-mods/horn-of-the-abyss/vcmi-1.7/screenshots/02.png",

--- a/vcmi-1.8.json
+++ b/vcmi-1.8.json
@@ -24,8 +24,7 @@
 				"https://raw.githubusercontent.com/vcmi-mods/horn-of-the-abyss/vcmi-1.7/screenshots/wiki3.png"
 			],
 			"downloadSize" : 246.063,
-			"githubStars" : 65,
-			"descriptionURL" : "https://raw.githubusercontent.com/vcmi-mods/horn-of-the-abyss/vcmi-1.7/hota/description.md"
+			"githubStars" : 65
 		},
 		"wake-of-gods" : {
 			"mod" : "https://raw.githubusercontent.com/vcmi-mods/wake-of-gods/vcmi-1.7/mod.json",


### PR DESCRIPTION
To be merged after VCMI 1.7.2 release and these changes done in HotA repo: 

1) rename current **vcmi-1.7** branch to **vcmi-1.7.0** 
2) make **hota-1.8.0** as default branch
3) rename **hota-1.8.0** to **vcmi-1.7**
4) run JSON CI manually in new **vcmi-1.7** branch

Workflow should automatically prepare Release package same as was tested with WoG and ToW, then can be merged and users will receive HotA 1.8.0 update