### PR TITLE
Add Hirki Plus Patch

### DIFF
--- a/vcmi-1.7.json
+++ b/vcmi-1.7.json
@@ -1512,7 +1512,7 @@
 		"hirki-plus-patch" : {
 		"mod" : "https://raw.githubusercontent.com/bewb3w/hirki-plus-patch/main/mod.json",
 		"download" : "https://github.com/bewb3w/hirki-plus-patch/archive/refs/heads/main.zip",
-		"downloadSize" : 2.065
+		"downloadSize" : 2.062
 		}
 	}
 }

--- a/vcmi-1.7.json
+++ b/vcmi-1.7.json
@@ -1508,6 +1508,11 @@
 				"https://raw.githubusercontent.com/vcmi-mods/reinforcements-spell/vcmi-1.7/screenshots/screen2.png",
 				"https://raw.githubusercontent.com/vcmi-mods/reinforcements-spell/vcmi-1.7/screenshots/screen3.png"
 			]
+		},
+		"hirki-plus-patch" : {
+		"mod" : "https://raw.githubusercontent.com/bewb3w/hirki-plus-patch/main/mod.json",
+		"download" : "https://github.com/bewb3w/hirki-plus-patch/archive/refs/heads/main.zip",
+		"downloadSize" : 2.065
 		}
 	}
 }

--- a/vcmi-1.7.json
+++ b/vcmi-1.7.json
@@ -1512,7 +1512,7 @@
 		"hirki-plus-patch" : {
 		"mod" : "https://raw.githubusercontent.com/bewb3w/hirki-plus-patch/main/mod.json",
 		"download" : "https://github.com/bewb3w/hirki-plus-patch/archive/refs/heads/main.zip",
-		"downloadSize" : 2.062
+		"downloadSize" : 3.204
 		}
 	}
 }


### PR DESCRIPTION
Adds Hirki Plus Patch (H.P.P.) to the VCMI 1.7 mods repository.

Hirki Plus Patch is a modular gameplay and balance patch for Heroes of Might and Magic III on VCMI, designed for use with Horn of the Abyss.

Source repository:
https://github.com/bewb3w/hirki-plus-patch

The mod targets VCMI 1.7.4 and uses HotA as a required dependency. It has been tested locally with HotA enabled.

Please label this PR as `new mod` if I cannot assign the label myself.