### PR TITLE
Update Hirki Plus Patch download size

### DIFF
--- a/vcmi-1.7.json
+++ b/vcmi-1.7.json
@@ -1512,7 +1512,7 @@
 		"hirki-plus-patch" : {
 			"mod" : "https://raw.githubusercontent.com/bewb3w/hirki-plus-patch/main/mod.json",
 			"download" : "https://github.com/bewb3w/hirki-plus-patch/archive/refs/heads/main.zip",
-			"downloadSize" : 1.966,
+			"downloadSize" : 2.217,
 			"githubStars" : 0,
 			"descriptionURL" : "https://raw.githubusercontent.com/bewb3w/hirki-plus-patch/main/description.md"
 		}


### PR DESCRIPTION
Updates Hirki Plus Patch after the 1.1.0 release.

Changes:
- updates `downloadSize` for the current GitHub `main.zip`
- HPP 1.1.0 adds Polish localization, updated descriptions, restored/expanded map object modules, README, and license/contact metadata

Current ZIP size: 2,217,364 bytes
New `downloadSize`: 2.217