### PR TITLE
Add Dragon Citadel town mod

### DIFF
--- a/vcmi-1.7.json
+++ b/vcmi-1.7.json
@@ -1534,7 +1534,7 @@
 		"dragon-citadel" : {
 			"mod" : "https://raw.githubusercontent.com/czcmjkfvy4-dotcom/Jakubabuba/main/mod.json",
 			"download" : "https://github.com/czcmjkfvy4-dotcom/Jakubabuba/archive/refs/heads/main.zip",
-			"downloadSize" : 31.84,
+			"downloadSize" : 30.438,
 			"screenshots" : [
 				"https://raw.githubusercontent.com/czcmjkfvy4-dotcom/Jakubabuba/main/screenshots/town-screen.png",
 				"https://raw.githubusercontent.com/czcmjkfvy4-dotcom/Jakubabuba/main/screenshots/building-catalog.png"

--- a/vcmi-1.7.json
+++ b/vcmi-1.7.json
@@ -1530,6 +1530,15 @@
 			"download" : "https://github.com/vcmi-mods/hirki-plus-patch/releases/download/1.7/hirki-plus-patch-vcmi-1.7.zip",
 			"downloadSize" : 2.096,
 			"githubStars" : 2
+		},
+		"dragon-citadel" : {
+			"mod" : "https://raw.githubusercontent.com/czcmjkfvy4-dotcom/Jakubabuba/main/mod.json",
+			"download" : "https://github.com/czcmjkfvy4-dotcom/Jakubabuba/archive/refs/heads/main.zip",
+			"downloadSize" : 31.84,
+			"screenshots" : [
+				"https://raw.githubusercontent.com/czcmjkfvy4-dotcom/Jakubabuba/main/screenshots/town-screen.png",
+				"https://raw.githubusercontent.com/czcmjkfvy4-dotcom/Jakubabuba/main/screenshots/building-catalog.png"
+			]
 		}
 	}
 }

--- a/vcmi-1.7.json
+++ b/vcmi-1.7.json
@@ -1534,10 +1534,10 @@
 		"dragon-citadel" : {
 			"mod" : "https://raw.githubusercontent.com/czcmjkfvy4-dotcom/Jakubabuba/main/mod.json",
 			"download" : "https://github.com/czcmjkfvy4-dotcom/Jakubabuba/archive/refs/heads/main.zip",
-			"downloadSize" : 30.446,
+			"downloadSize" : 31.010,
 			"screenshots" : [
 				"https://raw.githubusercontent.com/czcmjkfvy4-dotcom/Jakubabuba/main/screenshots/town-screen.png",
-				"https://raw.githubusercontent.com/czcmjkfvy4-dotcom/Jakubabuba/main/screenshots/building-catalog.png"
+				"https://raw.githubusercontent.com/czcmjkfvy4-dotcom/Jakubabuba/main/screenshots/creature-roster.jpg"
 			]
 		}
 	}

--- a/vcmi-1.7.json
+++ b/vcmi-1.7.json
@@ -1534,10 +1534,12 @@
 		"dragon-citadel" : {
 			"mod" : "https://raw.githubusercontent.com/czcmjkfvy4-dotcom/Jakubabuba/main/mod.json",
 			"download" : "https://github.com/czcmjkfvy4-dotcom/Jakubabuba/archive/refs/heads/main.zip",
-			"downloadSize" : 31.008,
+			"downloadSize" : 66.782,
 			"screenshots" : [
 				"https://raw.githubusercontent.com/czcmjkfvy4-dotcom/Jakubabuba/main/screenshots/town-screen.png",
-				"https://raw.githubusercontent.com/czcmjkfvy4-dotcom/Jakubabuba/main/screenshots/creature-roster.jpg"
+				"https://raw.githubusercontent.com/czcmjkfvy4-dotcom/Jakubabuba/main/screenshots/creature-roster.jpg",
+				"https://raw.githubusercontent.com/czcmjkfvy4-dotcom/Jakubabuba/main/screenshots/level8-dragons.jpg",
+				"https://raw.githubusercontent.com/czcmjkfvy4-dotcom/Jakubabuba/main/screenshots/level8-sanctuaries.jpg"
 			]
 		}
 	}

--- a/vcmi-1.7.json
+++ b/vcmi-1.7.json
@@ -1534,7 +1534,7 @@
 		"dragon-citadel" : {
 			"mod" : "https://raw.githubusercontent.com/czcmjkfvy4-dotcom/Jakubabuba/main/mod.json",
 			"download" : "https://github.com/czcmjkfvy4-dotcom/Jakubabuba/archive/refs/heads/main.zip",
-			"downloadSize" : 30.438,
+			"downloadSize" : 30.446,
 			"screenshots" : [
 				"https://raw.githubusercontent.com/czcmjkfvy4-dotcom/Jakubabuba/main/screenshots/town-screen.png",
 				"https://raw.githubusercontent.com/czcmjkfvy4-dotcom/Jakubabuba/main/screenshots/building-catalog.png"

--- a/vcmi-1.7.json
+++ b/vcmi-1.7.json
@@ -1534,7 +1534,7 @@
 		"dragon-citadel" : {
 			"mod" : "https://raw.githubusercontent.com/czcmjkfvy4-dotcom/Jakubabuba/main/mod.json",
 			"download" : "https://github.com/czcmjkfvy4-dotcom/Jakubabuba/archive/refs/heads/main.zip",
-			"downloadSize" : 31.010,
+			"downloadSize" : 31.008,
 			"screenshots" : [
 				"https://raw.githubusercontent.com/czcmjkfvy4-dotcom/Jakubabuba/main/screenshots/town-screen.png",
 				"https://raw.githubusercontent.com/czcmjkfvy4-dotcom/Jakubabuba/main/screenshots/creature-roster.jpg"


### PR DESCRIPTION
Adds **Dragon Citadel (Smocza Cytadela)**, a complete custom town for VCMI.

## Current release

- Author: Billaden
- Mod version: 1.5.0
- Mod type: Town
- Minimum VCMI version: 1.7.4
- Default language: English
- Additional language: complete Polish localization
- Source: https://github.com/czcmjkfvy4-dotcom/Jakubabuba

## Highlights

- Eight creature tiers with corrected creature, garrison, portrait and battle mappings.
- Rebalanced early units, Titans, super dragons, dwelling costs and growth.
- Rebuilt grounded town layout, enlarged fortifications and enlarged adventure-map town.
- Entirely original level 8 Ultimate Dragon and Absolute Dragon, with original battle/map animations, portraits and matching town dwellings.
- Guarded Sanctuary at the End of Ages adventure-map object.
- Updated town, roster and level 8 showcase screenshots.

## VCMI compatibility

The main town and the included `Dragon Citadel: Endgame Rules` submod parse and load on stock VCMI 1.7.4. Stock VCMI uses the normal weekly fallback for the two rules it cannot express through mod data alone. The repository also documents an optional GPL source patch for an exact monthly level 8 growth rule and a deterministic 10% joining eligibility rule. `Dragon Citadel: Creator Tools` is a separate VCMI submod and is disabled by default.

## Validation

- Stock VCMI 1.7.4: `Parsing mod: OK`, `Loading mod: OK`, `All game content loaded`.
- Matching BILLADENC4 VCMI 1.7.4 build: same successful smoke test.
- 101 JSON files validated locally.
- English and Polish translation sets contain the same 228 keys.
- Official repository JSON validator passes.
- Download size measured from GitHub: 66.782 MiB.

The PR branch has also been synchronized with the current `develop` branch.