### PR TITLE
Add Shadowless Chinese Fonts (Noto Sans CJK SC)

### DIFF
--- a/vcmi-1.7.json
+++ b/vcmi-1.7.json
@@ -336,6 +336,12 @@
 			"downloadSize" : 16.962,
 			"githubStars" : 3
 		},
+		"shadowless-chinese-font" : {
+			"mod" : "https://raw.githubusercontent.com/aysuio/vcmi-shadowless-chinese-font/main/mod.json",
+			"download" : "https://github.com/aysuio/vcmi-shadowless-chinese-font/releases/download/v1.0.0/shadowless-chinese-font-v1.0.0.zip",
+			"downloadSize" : 13.669,
+			"githubStars" : 0
+		},
 		"french-translation" : {
 			"mod" : "https://raw.githubusercontent.com/vcmi-mods/french-translation/vcmi-1.7/french-translation/mod.json",
 			"download" : "https://github.com/vcmi-mods/french-translation/archive/refs/heads/vcmi-1.7.zip",


### PR DESCRIPTION
## Summary

Adds **Shadowless Chinese Fonts (Noto Sans CJK SC)** to the VCMI 1.7 repository index.

The mod:
- uses the static Regular build of OFL-licensed Noto Sans CJK SC;
- sets `noShadow: true` for every VCMI TrueType font role;
- targets VCMI 1.7.5+ and depends on the Chinese Translation TrueType Fonts submod;
- improves Simplified Chinese readability at high interface scaling, especially adventure-map object labels.

## Validation

- `vcmi-1.7.json` parses successfully.
- Public `mod.json` and release archive are available.
- Release asset SHA-256: `cd3d5dcd9f8c0069e03b62fe4678f1c778159b5d6e64ca9b47d36b3e6a318f1e`.
- Font license is included as `OFL.txt`.